### PR TITLE
Add missing `return` header to deprecated functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ Lazy accumulator, but is fixed as of [GHC 9.0.1](https://gitlab.haskell.org/ghc/
 
 ### Deprecated
 
+#### `return`
+
 Use `pure` instead.
 See https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
 


### PR DESCRIPTION
Thanks a ton for compiling this super helpful list!

A small PR fix - I believe the section about `return` being deprecated in favour of `pure` was missing the heading. This just adds it in :slightly_smiling_face: 