### PR TITLE
Ignored tuple-section hint

### DIFF
--- a/hlint.yaml
+++ b/hlint.yaml
@@ -1,4 +1,5 @@
 - ignore: { name: "Use unless" }
+- ignore: { name: "Use tuple-section" }
 
 - functions:
   - {name: unsafeDupablePerformIO, within: []} # Unsafe


### PR DESCRIPTION
We don't want to use tuple-section, so we should also disable the hint.