### PR TITLE
Warn for only Data.Ratio.%, not other %

### DIFF
--- a/hlint.yaml
+++ b/hlint.yaml
@@ -77,7 +77,7 @@
   - {name: realToFrac, within: []}
 
   # Constructs rationals, which is either wrong or a bad idea.
-  - {name: '%', within: []}
+  - {name: 'Data.Ratio.%', within: []}
 
   # Don't use string for command-line output.
   - {name: System.IO.putChar, within: []}


### PR DESCRIPTION
For example, optics uses % for lens composition.